### PR TITLE
Do not allow empty candidate when vote finalised

### DIFF
--- a/localgov_elections_reporting.module
+++ b/localgov_elections_reporting.module
@@ -573,4 +573,10 @@ function localgov_elections_reporting_area_vote_form_validation($form, \Drupal\C
       }
     }
   }
+
+  // Should not be able to finalise votes without having at least one candidate.
+  $finalised = $form_state->getValue('field_votes_finalised')['value'];
+  if($finalised && sizeof($candidate_keys) < 1){
+    $form_state->setErrorByName('field_candidates', t("You cannot finalise the votes with no candidates"));
+  }
 }


### PR DESCRIPTION
Enforces that at least one candidate is entered when votes are finalised. Relates to issue #18 