### PR TITLE
Feature: Menu group

### DIFF
--- a/config/optional/localgov_menu_link_group.localgov_menu_link_group.localgov_menu_link_group_election.yml
+++ b/config/optional/localgov_menu_link_group.localgov_menu_link_group.localgov_menu_link_group_election.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+    - localgov_elections_reporting
+    - localgov_menu_link_group
+id: localgov_menu_link_group_election
+group_label: Election
+weight: 13
+parent_menu: admin
+parent_menu_link: 'admin_toolbar_tools.extra_links:node.add'
+child_menu_links:
+  - 'admin_toolbar_tools.extra_links:node.add.election'
+  - 'admin_toolbar_tools.extra_links:node.add.division_vote'


### PR DESCRIPTION
Optional config file for the [localgov_menu_link_group](https://github.com/localgovdrupal/localgov_menu_link_group) module.

Creates following menu entries:
- Manage > Content > Add content > Election > Areas vote
- Manage > Content > Add content > Election > Election

### Screenshot
![screenshot-menu-link-group-election](https://github.com/localgovdrupal/localgov_elections_reporting/assets/50206849/4351248e-1472-4ea4-80f4-0ca7fd9b162e)
